### PR TITLE
feat: add admin node management

### DIFF
--- a/src/Flow.js
+++ b/src/Flow.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import ReactFlow, {
   addEdge,
   MiniMap,
@@ -16,6 +16,7 @@ import {
 
 import ImageNode from "./ImageNode";
 import AnimatedEdge from "./AnimatedEdge";
+import NodeModal from "./NodeModal";
 
 const edgeTypes = {
   animated: AnimatedEdge,
@@ -29,45 +30,103 @@ const nodeTypes = { imageNode: ImageNode };
 const OverviewFlow = () => {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalData, setModalData] = useState({ id: null, label: "", imageUrl: "" });
   const onConnect = useCallback(
     (params) => setEdges((eds) => addEdge(params, eds)),
     [setEdges]
   );
 
-  return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect}
-      onInit={onInit}
-      fitView
-      attributionPosition="top-right"
-      nodeTypes={nodeTypes}
-      // 3. ส่ง edgeTypes เป็น prop
-      edgeTypes={edgeTypes}
-    >
-      {/* SVG defs เดิม ไม่ต้องแก้ไข */}
-      <svg>
-        <defs>
-          <linearGradient id="edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop
-              offset="0%"
-              style={{ stopColor: "#ffc84d", stopOpacity: 1 }}
-            />
-            <stop
-              offset="100%"
-              style={{ stopColor: "#ffab00", stopOpacity: 1 }}
-            />
-          </linearGradient>
-        </defs>
-      </svg>
+  const openAddModal = () => {
+    setModalData({ id: null, label: "", imageUrl: "" });
+    setModalOpen(true);
+  };
 
-      <MiniMap />
-      <Controls />
-      <Background color="#aaa" gap={16} />
-    </ReactFlow>
+  const onNodeDoubleClick = useCallback((event, node) => {
+    setModalData({ id: node.id, label: node.data.label, imageUrl: node.data.imageUrl });
+    setModalOpen(true);
+  }, []);
+
+  const handleSave = (data) => {
+    if (data.id) {
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === data.id
+            ? { ...n, data: { ...n.data, label: data.label, imageUrl: data.imageUrl } }
+            : n
+        )
+      );
+    } else {
+      const id = `node_${+new Date()}`;
+      setNodes((nds) =>
+        nds.concat({
+          id,
+          type: "imageNode",
+          position: { x: 0, y: 0 },
+          data: { label: data.label, imageUrl: data.imageUrl, value: "" },
+        })
+      );
+    }
+    setModalOpen(false);
+  };
+
+  const handleDelete = (id) => {
+    setNodes((nds) => nds.filter((n) => n.id !== id));
+    setEdges((eds) => eds.filter((e) => e.source !== id && e.target !== id));
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        style={{ position: "absolute", zIndex: 4, right: 10, top: 10 }}
+        onClick={openAddModal}
+      >
+        Add Node
+      </button>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onNodeDoubleClick={onNodeDoubleClick}
+        onInit={onInit}
+        fitView
+        attributionPosition="top-right"
+        nodeTypes={nodeTypes}
+        // 3. ส่ง edgeTypes เป็น prop
+        edgeTypes={edgeTypes}
+      >
+        {/* SVG defs เดิม ไม่ต้องแก้ไข */}
+        <svg>
+          <defs>
+            <linearGradient id="edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop
+                offset="0%"
+                style={{ stopColor: "#ffc84d", stopOpacity: 1 }}
+              />
+              <stop
+                offset="100%"
+                style={{ stopColor: "#ffab00", stopOpacity: 1 }}
+              />
+            </linearGradient>
+          </defs>
+        </svg>
+
+        <MiniMap />
+        <Controls />
+        <Background color="#aaa" gap={16} />
+      </ReactFlow>
+      <NodeModal
+        isOpen={modalOpen}
+        data={modalData}
+        onChange={setModalData}
+        onSave={handleSave}
+        onDelete={handleDelete}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
   );
 };
 

--- a/src/NodeModal.css
+++ b/src/NodeModal.css
@@ -1,0 +1,35 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+}
+
+.modal {
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  min-width: 300px;
+}
+
+.modal label {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.modal input {
+  width: 100%;
+}
+
+.modal-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/src/NodeModal.js
+++ b/src/NodeModal.js
@@ -1,0 +1,34 @@
+import React from "react";
+import "./NodeModal.css";
+
+const NodeModal = ({ isOpen, data, onChange, onSave, onDelete, onClose }) => {
+  if (!isOpen) return null;
+
+  const handleChange = (e) => {
+    onChange({ ...data, [e.target.name]: e.target.value });
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h3>{data.id ? "Edit Node" : "Add Node"}</h3>
+        <label>
+          Name
+          <input name="label" value={data.label} onChange={handleChange} />
+        </label>
+        <label>
+          Icon URL
+          <input name="imageUrl" value={data.imageUrl} onChange={handleChange} />
+        </label>
+        <div className="modal-actions">
+          <button onClick={() => onSave(data)}>Save</button>
+          {data.id && <button onClick={() => onDelete(data.id)}>Delete</button>}
+          <button onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NodeModal;
+


### PR DESCRIPTION
## Summary
- add modal component for creating and editing nodes
- allow deleting nodes and updating edges
- expose add node button and double click editing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6892cf55768c832298f21344567a64bf