### PR TITLE
feat: enable edge drag and editing

### DIFF
--- a/src/EdgeModal.js
+++ b/src/EdgeModal.js
@@ -1,0 +1,29 @@
+import React from "react";
+import "./NodeModal.css";
+
+const EdgeModal = ({ isOpen, data, onChange, onSave, onDelete, onClose }) => {
+  if (!isOpen) return null;
+
+  const handleChange = (e) => {
+    onChange({ ...data, [e.target.name]: e.target.value });
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h3>Edit Edge</h3>
+        <label>
+          Label
+          <input name="label" value={data.label} onChange={handleChange} />
+        </label>
+        <div className="modal-actions">
+          <button onClick={() => onSave(data)}>Save</button>
+          <button onClick={() => onDelete(data.id)}>Delete</button>
+          <button onClick={onClose}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EdgeModal;

--- a/src/Flow.js
+++ b/src/Flow.js
@@ -6,6 +6,7 @@ import ReactFlow, {
   Background,
   useNodesState,
   useEdgesState,
+  updateEdge,
 } from "reactflow";
 import "reactflow/dist/style.css";
 
@@ -17,6 +18,7 @@ import {
 import ImageNode from "./ImageNode";
 import AnimatedEdge from "./AnimatedEdge";
 import NodeModal from "./NodeModal";
+import EdgeModal from "./EdgeModal";
 
 const edgeTypes = {
   animated: AnimatedEdge,
@@ -32,6 +34,8 @@ const OverviewFlow = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalData, setModalData] = useState({ id: null, label: "", imageUrl: "" });
+  const [edgeModalOpen, setEdgeModalOpen] = useState(false);
+  const [edgeModalData, setEdgeModalData] = useState({ id: null, label: "" });
   const onConnect = useCallback(
     (params) => setEdges((eds) => addEdge(params, eds)),
     [setEdges]
@@ -45,6 +49,11 @@ const OverviewFlow = () => {
   const onNodeDoubleClick = useCallback((event, node) => {
     setModalData({ id: node.id, label: node.data.label, imageUrl: node.data.imageUrl });
     setModalOpen(true);
+  }, []);
+
+  const onEdgeDoubleClick = useCallback((event, edge) => {
+    setEdgeModalData({ id: edge.id, label: edge.label || "" });
+    setEdgeModalOpen(true);
   }, []);
 
   const handleSave = (data) => {
@@ -76,6 +85,22 @@ const OverviewFlow = () => {
     setModalOpen(false);
   };
 
+  const handleEdgeSave = (data) => {
+    setEdges((eds) => eds.map((e) => (e.id === data.id ? { ...e, label: data.label } : e)));
+    setEdgeModalOpen(false);
+  };
+
+  const handleEdgeDelete = (id) => {
+    setEdges((eds) => eds.filter((e) => e.id !== id));
+    setEdgeModalOpen(false);
+  };
+
+  const onEdgeUpdate = useCallback(
+    (oldEdge, newConnection) =>
+      setEdges((els) => updateEdge(oldEdge, newConnection, els)),
+    [setEdges]
+  );
+
   return (
     <>
       <button
@@ -91,8 +116,11 @@ const OverviewFlow = () => {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         onNodeDoubleClick={onNodeDoubleClick}
+        onEdgeDoubleClick={onEdgeDoubleClick}
+        onEdgeUpdate={onEdgeUpdate}
         onInit={onInit}
         fitView
+        edgesUpdatable
         attributionPosition="top-right"
         nodeTypes={nodeTypes}
         // 3. ส่ง edgeTypes เป็น prop
@@ -125,6 +153,14 @@ const OverviewFlow = () => {
         onSave={handleSave}
         onDelete={handleDelete}
         onClose={() => setModalOpen(false)}
+      />
+      <EdgeModal
+        isOpen={edgeModalOpen}
+        data={edgeModalData}
+        onChange={setEdgeModalData}
+        onSave={handleEdgeSave}
+        onDelete={handleEdgeDelete}
+        onClose={() => setEdgeModalOpen(false)}
       />
     </>
   );

--- a/src/initial-elements.js
+++ b/src/initial-elements.js
@@ -57,6 +57,7 @@ export const edges = [
     target: "load",
     //markerEnd: { type: MarkerType.ArrowClosed },
     type: "animated",
+    label: "Solar to Load",
   },
   {
     id: "solar-to-battery",
@@ -64,6 +65,7 @@ export const edges = [
     target: "battery",
     //markerEnd: { type: MarkerType.ArrowClosed },
     type: "animated",
+    label: "Solar to Battery",
   },
   {
     id: "grid-to-load",
@@ -71,5 +73,6 @@ export const edges = [
     target: "load",
     //markerEnd: { type: MarkerType.ArrowClosed },
     type: "animated",
+    label: "Grid to Load",
   },
 ];


### PR DESCRIPTION
## Summary
- allow edges to be updated by dragging to new connections
- add modal for editing or deleting edges
- seed initial edges with labels for editing

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6892d206ca1c832289ab2c5a29601733