### PR TITLE
Ensure new edges use animated style

### DIFF
--- a/src/Flow.js
+++ b/src/Flow.js
@@ -37,7 +37,8 @@ const OverviewFlow = () => {
   const [edgeModalOpen, setEdgeModalOpen] = useState(false);
   const [edgeModalData, setEdgeModalData] = useState({ id: null, label: "" });
   const onConnect = useCallback(
-    (params) => setEdges((eds) => addEdge(params, eds)),
+    (params) =>
+      setEdges((eds) => addEdge({ ...params, type: "animated" }, eds)),
     [setEdges]
   );
 
@@ -55,6 +56,35 @@ const OverviewFlow = () => {
     setEdgeModalData({ id: edge.id, label: edge.label || "" });
     setEdgeModalOpen(true);
   }, []);
+
+  const onNodesDelete = useCallback(
+    (deleted) => {
+      setEdges((eds) =>
+        eds.filter((e) => !deleted.some((n) => e.source === n.id || e.target === n.id))
+      );
+    },
+    [setEdges]
+  );
+
+  const onEdgesDelete = useCallback(
+    (deleted) => {
+      setEdges((eds) => eds.filter((e) => !deleted.some((de) => de.id === e.id)));
+    },
+    [setEdges]
+  );
+
+  const exportConfig = () => {
+    const dataStr = JSON.stringify({ nodes, edges }, null, 2);
+    const blob = new Blob([dataStr], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "config.json";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
 
   const handleSave = (data) => {
     if (data.id) {
@@ -109,11 +139,19 @@ const OverviewFlow = () => {
       >
         Add Node
       </button>
+      <button
+        style={{ position: "absolute", zIndex: 4, right: 10, top: 50 }}
+        onClick={exportConfig}
+      >
+        Export Config
+      </button>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onNodesDelete={onNodesDelete}
+        onEdgesDelete={onEdgesDelete}
         onConnect={onConnect}
         onNodeDoubleClick={onNodeDoubleClick}
         onEdgeDoubleClick={onEdgeDoubleClick}


### PR DESCRIPTION
## Summary
- Ensure edges created via onConnect use the `animated` type so they match existing edge animation
- Allow removing nodes and edges and add button for exporting current graph to config file

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892d37498a88322916601afb4c514dc